### PR TITLE
Updated IdentityServer4 to update1

### DIFF
--- a/src/TwentyTwenty.IdentityServer4.EntityFramework7/Serialization/ClaimsPrincipalConverter.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFramework7/Serialization/ClaimsPrincipalConverter.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json;
 using System;
 using System.Linq;
 using System.Security.Claims;
+using IdentityModel;
 
 namespace TwentyTwenty.IdentityServer4.EntityFramework7.Serialization
 {
@@ -25,7 +26,7 @@ namespace TwentyTwenty.IdentityServer4.EntityFramework7.Serialization
             if (source == null) return null;
 
             var claims = source.Claims.Select(x => new Claim(x.Type, x.Value));
-            var id = new ClaimsIdentity(claims, source.AuthenticationType, Constants.ClaimTypes.Name, Constants.ClaimTypes.Role);
+            var id = new ClaimsIdentity(claims, source.AuthenticationType, JwtClaimTypes.Name, JwtClaimTypes.Role);
             var target = new ClaimsPrincipal(id);
             return target;
         }

--- a/src/TwentyTwenty.IdentityServer4.EntityFramework7/project.json
+++ b/src/TwentyTwenty.IdentityServer4.EntityFramework7/project.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "AutoMapper": "4.1.1",
     "Newtonsoft.Json": "8.0.2",
-    "IdentityServer4": "1.0.0-beta1",
+    "IdentityServer4": "1.0.0-beta1-update1" ,
     "Microsoft.Extensions.DependencyInjection": "1.0.0-rc1-final",
     "EntityFramework.Core": "7.0.0-rc1-final",
     "EntityFramework.Relational": "7.0.0-rc1-final"

--- a/test/TwentyTwenty.IdentityServer4.EntityFramework7.Tests/Serialization/ClaimConverterTests.cs
+++ b/test/TwentyTwenty.IdentityServer4.EntityFramework7.Tests/Serialization/ClaimConverterTests.cs
@@ -1,6 +1,7 @@
 ﻿using IdentityServer4.Core;
 using Newtonsoft.Json;
 using System.Security.Claims;
+using IdentityModel;
 using TwentyTwenty.IdentityServer4.EntityFramework7.Serialization;
 using Xunit;
 
@@ -11,14 +12,14 @@ namespace TwentyTwenty.IdentityServer4.EntityFramework7.Tests.Serialization
         [Fact]
         public void CanSerializeAndDeserializeAClaim()
         {
-            var claim = new Claim(Constants.ClaimTypes.Subject, "alice");
+            var claim = new Claim(JwtClaimTypes.Subject, "alice");
 
             var settings = new JsonSerializerSettings();
             settings.Converters.Add(new ClaimConverter());
             var json = JsonConvert.SerializeObject(claim, settings);
 
             claim = JsonConvert.DeserializeObject<Claim>(json, settings);
-            Assert.Equal(Constants.ClaimTypes.Subject, claim.Type);
+            Assert.Equal(JwtClaimTypes.Subject, claim.Type);
             Assert.Equal("alice", claim.Value);
         }
     }

--- a/test/TwentyTwenty.IdentityServer4.EntityFramework7.Tests/Serialization/ClaimsPrincipalConverterTests.cs
+++ b/test/TwentyTwenty.IdentityServer4.EntityFramework7.Tests/Serialization/ClaimsPrincipalConverterTests.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json;
 using System.Linq;
 using System.Security.Claims;
+using IdentityModel;
 using TwentyTwenty.IdentityServer4.EntityFramework7.Serialization;
 using Xunit;
 
@@ -13,11 +14,11 @@ namespace TwentyTwenty.IdentityServer4.EntityFramework7.Tests.Serialization
         public void CanSerializeAndDeserializeAClaimsPrincipal()
         {
             var claims = new Claim[]{
-                new Claim(Constants.ClaimTypes.Subject, "alice"),
-                new Claim(Constants.ClaimTypes.Scope, "read"),
-                new Claim(Constants.ClaimTypes.Scope, "write"),
+                new Claim(JwtClaimTypes.Subject, "alice"),
+                new Claim(JwtClaimTypes.Scope, "read"),
+                new Claim(JwtClaimTypes.Scope, "write"),
             };
-            var ci = new ClaimsIdentity(claims, Constants.AuthenticationMethods.Password);
+            var ci = new ClaimsIdentity(claims, OidcConstants.AuthenticationMethods.Password);
             var cp = new ClaimsPrincipal(ci);
 
             var settings = new JsonSerializerSettings();
@@ -25,11 +26,11 @@ namespace TwentyTwenty.IdentityServer4.EntityFramework7.Tests.Serialization
             var json = JsonConvert.SerializeObject(cp, settings);
 
             cp = JsonConvert.DeserializeObject<ClaimsPrincipal>(json, settings);
-            Assert.Equal(Constants.AuthenticationMethods.Password, cp.Identity.AuthenticationType);
+            Assert.Equal(OidcConstants.AuthenticationMethods.Password, cp.Identity.AuthenticationType);
             Assert.Equal(3, cp.Claims.Count());
-            Assert.True(cp.HasClaim(Constants.ClaimTypes.Subject, "alice"));
-            Assert.True(cp.HasClaim(Constants.ClaimTypes.Scope, "read"));
-            Assert.True(cp.HasClaim(Constants.ClaimTypes.Scope, "write"));
+            Assert.True(cp.HasClaim(JwtClaimTypes.Subject, "alice"));
+            Assert.True(cp.HasClaim(JwtClaimTypes.Scope, "read"));
+            Assert.True(cp.HasClaim(JwtClaimTypes.Scope, "write"));
         }
     }
 }


### PR DESCRIPTION
Claim constants were moved in IdentityServer4: https://github.com/IdentityServer/IdentityServer4/commit/af2b047bba62044d8458c6f3699e4b77201014d9

Uses new Constants class, JwtClaimType
