### PR TITLE
Sync with IdentityServer4 (1.0.0-beta3) official update, remove ".Core" in namespace

### DIFF
--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Entities/Client.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Entities/Client.cs
@@ -1,4 +1,4 @@
-﻿using IdentityServer4.Core.Models;
+﻿using IdentityServer4.Models;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/EntityFrameworkOptions.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/EntityFrameworkOptions.cs
@@ -1,6 +1,6 @@
 ﻿using AutoMapper;
-using IdentityServer4.Core.Models;
-using IdentityServer4.Core.Services;
+using IdentityServer4.Models;
+using IdentityServer4.Services;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using TwentyTwenty.IdentityServer4.EntityFrameworkCore.DbContexts;

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Extensions/EntitiesMap.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Extensions/EntitiesMap.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Extensions;
-using Models = IdentityServer4.Core.Models;
+using Models = IdentityServer4.Models;
 
 namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.Entities
 {

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Extensions/ModelsMap.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Extensions/ModelsMap.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Security.Claims;
 using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Entities;
 
-namespace IdentityServer4.Core.Models
+namespace IdentityServer4.Models
 {
     public class ModelsMapProfile<TKey> : Profile
         where TKey : IEquatable<TKey>

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Serialization/ClaimsPrincipalConverter.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Serialization/ClaimsPrincipalConverter.cs
@@ -1,5 +1,4 @@
-﻿using IdentityServer4.Core;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using System;
 using System.Linq;
 using System.Security.Claims;

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Serialization/ClientConverter.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Serialization/ClientConverter.cs
@@ -1,5 +1,5 @@
-﻿using IdentityServer4.Core.Models;
-using IdentityServer4.Core.Services;
+﻿using IdentityServer4.Models;
+using IdentityServer4.Services;
 using Newtonsoft.Json;
 using System;
 

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Serialization/ScopeConverter.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Serialization/ScopeConverter.cs
@@ -1,8 +1,8 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Linq;
-using IdentityServer4.Core.Models;
-using IdentityServer4.Core.Services;
+using IdentityServer4.Models;
+using IdentityServer4.Services;
 
 namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.Serialization
 {

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Services/ClientConfigurationCorsPolicyService.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Services/ClientConfigurationCorsPolicyService.cs
@@ -1,4 +1,4 @@
-﻿using IdentityServer4.Core.Services;
+﻿using IdentityServer4.Services;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Linq;

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Stores/AuthorizationCodeStore.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Stores/AuthorizationCodeStore.cs
@@ -1,5 +1,5 @@
-﻿using IdentityServer4.Core.Models;
-using IdentityServer4.Core.Services;
+﻿using IdentityServer4.Models;
+using IdentityServer4.Services;
 using System;
 using System.Threading.Tasks;
 using TwentyTwenty.IdentityServer4.EntityFrameworkCore.DbContexts;

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Stores/BaseTokenStore.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Stores/BaseTokenStore.cs
@@ -1,5 +1,5 @@
-﻿using IdentityServer4.Core.Models;
-using IdentityServer4.Core.Services;
+﻿using IdentityServer4.Models;
+using IdentityServer4.Services;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 using System;

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Stores/ClientStore.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Stores/ClientStore.cs
@@ -1,10 +1,10 @@
-﻿using IdentityServer4.Core.Services;
+﻿using IdentityServer4.Services;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Threading.Tasks;
 using TwentyTwenty.IdentityServer4.EntityFrameworkCore.DbContexts;
 using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Entities;
-using Models = IdentityServer4.Core.Models;
+using Models = IdentityServer4.Models;
 
 namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.Stores
 {

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Stores/ConsentStore.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Stores/ConsentStore.cs
@@ -1,4 +1,4 @@
-﻿using IdentityServer4.Core.Services;
+﻿using IdentityServer4.Services;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using TwentyTwenty.IdentityServer4.EntityFrameworkCore.DbContexts;
 using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Extensions;
-using Models = IdentityServer4.Core.Models;
+using Models = IdentityServer4.Models;
 
 namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.Stores
 {

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Stores/RefreshTokenStore.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Stores/RefreshTokenStore.cs
@@ -1,5 +1,5 @@
-﻿using IdentityServer4.Core.Models;
-using IdentityServer4.Core.Services;
+﻿using IdentityServer4.Models;
+using IdentityServer4.Services;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Linq;

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Stores/ScopeStore.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Stores/ScopeStore.cs
@@ -1,9 +1,9 @@
-﻿using IdentityServer4.Core.Services;
+﻿using IdentityServer4.Services;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Models = IdentityServer4.Core.Models;
+using Models = IdentityServer4.Models;
 using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Entities;
 using TwentyTwenty.IdentityServer4.EntityFrameworkCore.DbContexts;
 using Microsoft.EntityFrameworkCore;

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Stores/TokenHandleStore.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Stores/TokenHandleStore.cs
@@ -1,5 +1,5 @@
-﻿using IdentityServer4.Core.Models;
-using IdentityServer4.Core.Services;
+﻿using IdentityServer4.Models;
+using IdentityServer4.Services;
 using System;
 using System.Threading.Tasks;
 using TwentyTwenty.IdentityServer4.EntityFrameworkCore.DbContexts;

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/project.json
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/project.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "AutoMapper": "4.2.1",
     "Newtonsoft.Json": "8.0.3",
-    "IdentityServer4": "1.0.0-beta2" ,
+    "IdentityServer4": "1.0.0-beta3" ,
     "Microsoft.Extensions.DependencyInjection": "1.0.0-rc2-final",
     "Microsoft.EntityFrameworkCore": "1.0.0-rc2-final",
     "Microsoft.EntityFrameworkCore.Relational": "1.0.0-rc2-final"

--- a/test/TwentyTwenty.IdentityServer4.EntityFrameworkCore.IntegrationTests/AutomapperTests.cs
+++ b/test/TwentyTwenty.IdentityServer4.EntityFrameworkCore.IntegrationTests/AutomapperTests.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Entities;
 using Xunit;
-using Models = IdentityServer4.Core.Models;
+using Models = IdentityServer4.Models;
 
 namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.IntegrationTests
 {

--- a/test/TwentyTwenty.IdentityServer4.EntityFrameworkCore.Tests/Serialization/ClaimConverterTests.cs
+++ b/test/TwentyTwenty.IdentityServer4.EntityFrameworkCore.Tests/Serialization/ClaimConverterTests.cs
@@ -1,5 +1,4 @@
-﻿using IdentityServer4.Core;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using System.Security.Claims;
 using IdentityModel;
 using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Serialization;

--- a/test/TwentyTwenty.IdentityServer4.EntityFrameworkCore.Tests/Serialization/ClientConverterTests.cs
+++ b/test/TwentyTwenty.IdentityServer4.EntityFrameworkCore.Tests/Serialization/ClientConverterTests.cs
@@ -1,6 +1,6 @@
-﻿using IdentityServer4.Core;
-using IdentityServer4.Core.Models;
-using IdentityServer4.Core.Services.InMemory;
+﻿using IdentityServer4;
+using IdentityServer4.Models;
+using IdentityServer4.Services.InMemory;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Security.Claims;

--- a/test/TwentyTwenty.IdentityServer4.EntityFrameworkCore.Tests/Serialization/ScopeConverterTests.cs
+++ b/test/TwentyTwenty.IdentityServer4.EntityFrameworkCore.Tests/Serialization/ScopeConverterTests.cs
@@ -1,5 +1,5 @@
-﻿using IdentityServer4.Core.Models;
-using IdentityServer4.Core.Services.InMemory;
+﻿using IdentityServer4.Models;
+using IdentityServer4.Services.InMemory;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Serialization;


### PR DESCRIPTION
Sync with IdentityServer4 (1.0.0-beta3) official update, remove ".Core" in namespace.
such as that, change "IdentityServer4.Core.Models" to "IdentityServer4.Models".

IdentityServer4's update could be found by visiting:  [ Removed .Core from namespaces ](https://github.com/IdentityServer/IdentityServer4/commit/4831ba4c46d545b4574ed04aef54a6b45eaef551)
