### PR TITLE
Refactored Contexts into Interfaces

### DIFF
--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/DbContexts/ClientConfigurationContext.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/DbContexts/ClientConfigurationContext.cs
@@ -1,11 +1,11 @@
 ﻿using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata;
 using System;
 using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Entities;
+using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Interfaces;
 
 namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.DbContexts
 {
-    public class ClientConfigurationContext<TKey> : DbContext
+    public class ClientConfigurationContext<TKey> : DbContext, IClientConfigurationContext<TKey>
         where TKey : IEquatable<TKey>
     {
         public ClientConfigurationContext(DbContextOptions options)
@@ -16,61 +16,9 @@ namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.DbContexts
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<Client<TKey>>(b =>
-            {
-                b.ToTable(EfConstants.TableNames.Client);
-                b.HasMany(e => e.ClientSecrets).WithOne(e => e.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
-                b.HasMany(e => e.RedirectUris).WithOne(e => e.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
-                b.HasMany(e => e.PostLogoutRedirectUris).WithOne(e => e.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
-                b.HasMany(e => e.AllowedScopes).WithOne(e => e.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
-                b.HasMany(e => e.IdentityProviderRestrictions).WithOne(e => e.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
-                b.HasMany(e => e.ClientSecrets).WithOne(e => e.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
-                b.HasMany(e => e.AllowedCorsOrigins).WithOne(e => e.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
-                b.HasMany(e => e.AllowedGrantTypes).WithOne(e => e.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
-                b.HasIndex(e => e.ClientId).IsUnique();
-                b.Property(e => e.ClientId).IsRequired().HasMaxLength(200);
-                b.Property(e => e.ClientName).IsRequired().HasMaxLength(200);
-                b.Property(e => e.ClientUri).HasMaxLength(2000);
-            });                
+            modelBuilder.ConfigureClientContext<TKey>();
 
-            modelBuilder.Entity<ClientClaim<TKey>>(b =>
-            {
-                b.ToTable(EfConstants.TableNames.ClientClaim);
-                b.Property(e => e.Type).IsRequired().HasMaxLength(250);
-                b.Property(e => e.Value).IsRequired().HasMaxLength(250);
-            });                
-
-            modelBuilder.Entity<ClientCorsOrigin<TKey>>()
-                .ToTable(EfConstants.TableNames.ClientCorsOrigin)
-                .Property(e => e.Origin).IsRequired().HasMaxLength(150);
-
-            modelBuilder.Entity<ClientGrantType<TKey>>()
-                .ToTable(EfConstants.TableNames.ClientGrantType)
-                .Property(e => e.GrantType).IsRequired().HasMaxLength(150);
-
-            modelBuilder.Entity<ClientPostLogoutRedirectUri<TKey>>()
-                .ToTable(EfConstants.TableNames.ClientPostLogoutRedirectUri)
-                .Property(e => e.Uri).IsRequired().HasMaxLength(2000);
-
-            modelBuilder.Entity<ClientProviderRestriction<TKey>>()
-                .ToTable(EfConstants.TableNames.ClientProviderRestriction)
-                .Property(e => e.Provider).IsRequired().HasMaxLength(200);
-
-            modelBuilder.Entity<ClientRedirectUri<TKey>>()
-                .ToTable(EfConstants.TableNames.ClientRedirectUri)
-                .Property(e => e.Uri).IsRequired().HasMaxLength(2000);
-
-            modelBuilder.Entity<ClientScope<TKey>>()
-                .ToTable(EfConstants.TableNames.ClientScopes)
-                .Property(e => e.Scope).IsRequired().HasMaxLength(200);
-
-            modelBuilder.Entity<ClientSecret<TKey>>(b =>
-            {
-                b.ToTable(EfConstants.TableNames.ClientSecret);
-                b.Property(e => e.Value).IsRequired().HasMaxLength(250);
-                b.Property(e => e.Type).HasMaxLength(250);
-                b.Property(e => e.Description).HasMaxLength(2000);
-            });                
+            base.OnModelCreating(modelBuilder);
         }
     }
 }

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/DbContexts/OperationalContext.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/DbContexts/OperationalContext.cs
@@ -1,9 +1,10 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Entities;
+using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Interfaces;
 
 namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.DbContexts
 {
-    public class OperationalContext : DbContext
+    public class OperationalContext : DbContext, IOperationalContext
     {
         public OperationalContext(DbContextOptions options)
             : base(options)
@@ -15,24 +16,9 @@ namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.DbContexts
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<Consent>(b =>
-            {
-                b.ToTable(EfConstants.TableNames.Consent);
-                b.Property(e => e.SubjectId).HasMaxLength(200);
-                b.Property(e => e.ClientId).HasMaxLength(200);
-                b.Property(e => e.Scopes).IsRequired().HasMaxLength(2000);
-                b.HasKey(e => new { e.SubjectId, e.ClientId });
-            });
-            
-            modelBuilder.Entity<Token>(b =>
-            {
-                b.ToTable(EfConstants.TableNames.Token);
-                b.Property(e => e.SubjectId).HasMaxLength(200);
-                b.Property(e => e.ClientId).IsRequired().HasMaxLength(200);
-                b.Property(e => e.JsonCode).IsRequired();
-                b.Property(e => e.Expiry).IsRequired();
-                b.HasKey(e => new { e.Key, e.TokenType });
-            });                
+            modelBuilder.ConfigureOperationalContext();
+
+            base.OnModelCreating(modelBuilder);
         }
     }
 }

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/DbContexts/ScopeConfigurationContext.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/DbContexts/ScopeConfigurationContext.cs
@@ -1,11 +1,11 @@
 ﻿using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata;
 using System;
 using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Entities;
+using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Interfaces;
 
 namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.DbContexts
 {
-    public class ScopeConfigurationContext<TKey> : DbContext
+    public class ScopeConfigurationContext<TKey> : DbContext, IScopeConfigurationContext<TKey>
         where TKey : IEquatable<TKey>
     {
         public ScopeConfigurationContext(DbContextOptions options)
@@ -16,31 +16,9 @@ namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.DbContexts
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<ScopeClaim<TKey>>(b =>
-            {
-                b.ToTable(EfConstants.TableNames.ScopeClaim);
-                b.Property(e => e.Name).IsRequired().HasMaxLength(200);
-                b.Property(e => e.Description).HasMaxLength(1000);
-            });
+            modelBuilder.ConfigureScopeConfigurationContext<TKey>();
 
-            modelBuilder.Entity<ScopeSecret<TKey>>(b =>
-            {
-                b.ToTable(EfConstants.TableNames.ScopeSecrets);
-                b.Property(e => e.Description).HasMaxLength(1000);
-                b.Property(e => e.Type).HasMaxLength(250);
-                b.Property(e => e.Value).IsRequired().HasMaxLength(250);
-            });
-
-            modelBuilder.Entity<Scope<TKey>>(b =>
-            {
-                b.ToTable(EfConstants.TableNames.Scope);
-                b.HasMany(e => e.ScopeClaims).WithOne(e => e.Scope).OnDelete(DeleteBehavior.Cascade);
-                b.HasMany(e => e.ScopeSecrets).WithOne(e => e.Scope).OnDelete(DeleteBehavior.Cascade);
-                b.Property(e => e.Name).IsRequired().HasMaxLength(200);
-                b.Property(e => e.DisplayName).HasMaxLength(200);
-                b.Property(e => e.Description).HasMaxLength(1000);
-                b.Property(e => e.ClaimsRule).HasMaxLength(200);
-            });
+            base.OnModelCreating(modelBuilder);
         }
     }
 }

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/EntityFrameworkOptions.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/EntityFrameworkOptions.cs
@@ -3,6 +3,7 @@ using IdentityServer4.Stores;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using TwentyTwenty.IdentityServer4.EntityFrameworkCore.DbContexts;
+using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Interfaces;
 using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Services;
 using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Stores;
 
@@ -23,9 +24,9 @@ namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore
         }
 
         public EntityFrameworkOptions RegisterOperationalStores<TOperationalContext>()
-            where TOperationalContext : OperationalContext
+            where TOperationalContext : class, IOperationalContext
         {
-            _builder.Services.AddScoped<OperationalContext, TOperationalContext>();
+            _builder.Services.AddScoped<IOperationalContext, TOperationalContext>();
             _builder.Services.AddScoped<IPersistedGrantService, PersistedGrantService>();
 
             return this;
@@ -33,9 +34,9 @@ namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore
 
         public EntityFrameworkOptions RegisterClientStore<TKey, TClientContext>()
             where TKey : IEquatable<TKey>
-            where TClientContext : ClientConfigurationContext<TKey>
+            where TClientContext : class, IClientConfigurationContext<TKey>
         {
-            _builder.Services.AddScoped<ClientConfigurationContext<TKey>, TClientContext>();
+            _builder.Services.AddScoped<IClientConfigurationContext<TKey>, TClientContext>();
             _builder.Services.AddScoped<IClientStore, ClientStore<TKey>>();
             _builder.Services.AddScoped<ICorsPolicyService, ClientConfigurationCorsPolicyService<TKey>>();
 
@@ -44,9 +45,9 @@ namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore
 
         public EntityFrameworkOptions RegisterScopeStore<TKey, TScopeContext>()
             where TKey : IEquatable<TKey>
-            where TScopeContext : ScopeConfigurationContext<TKey>
+            where TScopeContext : class, IScopeConfigurationContext<TKey>
         {
-            _builder.Services.AddScoped<ScopeConfigurationContext<TKey>, TScopeContext>();
+            _builder.Services.AddScoped<IScopeConfigurationContext<TKey>, TScopeContext>();
             _builder.Services.AddScoped<IScopeStore, ScopeStore<TKey>>();
 
             return this;

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -1,0 +1,122 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using System;
+using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Entities;
+
+namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore
+{
+    public static class ModelBuilderExtensions
+    {
+        public static void ConfigureClientContext<TKey>(this ModelBuilder modelBuilder)
+            where TKey : IEquatable<TKey>
+        {
+            modelBuilder.Entity<Client<TKey>>(b =>
+            {
+                b.ToTable(EfConstants.TableNames.Client);
+                b.HasMany(e => e.ClientSecrets).WithOne(e => e.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
+                b.HasMany(e => e.RedirectUris).WithOne(e => e.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
+                b.HasMany(e => e.PostLogoutRedirectUris).WithOne(e => e.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
+                b.HasMany(e => e.AllowedScopes).WithOne(e => e.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
+                b.HasMany(e => e.IdentityProviderRestrictions).WithOne(e => e.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
+                b.HasMany(e => e.ClientSecrets).WithOne(e => e.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
+                b.HasMany(e => e.AllowedCorsOrigins).WithOne(e => e.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
+                b.HasMany(e => e.AllowedGrantTypes).WithOne(e => e.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
+                b.HasIndex(e => e.ClientId).IsUnique();
+                b.Property(e => e.ClientId).IsRequired().HasMaxLength(200);
+                b.Property(e => e.ClientName).IsRequired().HasMaxLength(200);
+                b.Property(e => e.ClientUri).HasMaxLength(2000);
+            });
+
+            modelBuilder.Entity<ClientClaim<TKey>>(b =>
+            {
+                b.ToTable(EfConstants.TableNames.ClientClaim);
+                b.Property(e => e.Type).IsRequired().HasMaxLength(250);
+                b.Property(e => e.Value).IsRequired().HasMaxLength(250);
+            });
+
+            modelBuilder.Entity<ClientCorsOrigin<TKey>>()
+                .ToTable(EfConstants.TableNames.ClientCorsOrigin)
+                .Property(e => e.Origin).IsRequired().HasMaxLength(150);
+
+            modelBuilder.Entity<ClientGrantType<TKey>>()
+                .ToTable(EfConstants.TableNames.ClientGrantType)
+                .Property(e => e.GrantType).IsRequired().HasMaxLength(150);
+
+            modelBuilder.Entity<ClientPostLogoutRedirectUri<TKey>>()
+                .ToTable(EfConstants.TableNames.ClientPostLogoutRedirectUri)
+                .Property(e => e.Uri).IsRequired().HasMaxLength(2000);
+
+            modelBuilder.Entity<ClientProviderRestriction<TKey>>()
+                .ToTable(EfConstants.TableNames.ClientProviderRestriction)
+                .Property(e => e.Provider).IsRequired().HasMaxLength(200);
+
+            modelBuilder.Entity<ClientRedirectUri<TKey>>()
+                .ToTable(EfConstants.TableNames.ClientRedirectUri)
+                .Property(e => e.Uri).IsRequired().HasMaxLength(2000);
+
+            modelBuilder.Entity<ClientScope<TKey>>()
+                .ToTable(EfConstants.TableNames.ClientScopes)
+                .Property(e => e.Scope).IsRequired().HasMaxLength(200);
+
+            modelBuilder.Entity<ClientSecret<TKey>>(b =>
+            {
+                b.ToTable(EfConstants.TableNames.ClientSecret);
+                b.Property(e => e.Value).IsRequired().HasMaxLength(250);
+                b.Property(e => e.Type).HasMaxLength(250);
+                b.Property(e => e.Description).HasMaxLength(2000);
+            });
+        }
+
+        public static void ConfigureOperationalContext(this ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Consent>(b =>
+            {
+                b.ToTable(EfConstants.TableNames.Consent);
+                b.Property(e => e.SubjectId).HasMaxLength(200);
+                b.Property(e => e.ClientId).HasMaxLength(200);
+                b.Property(e => e.Scopes).IsRequired().HasMaxLength(2000);
+                b.HasKey(e => new { e.SubjectId, e.ClientId });
+            });
+
+            modelBuilder.Entity<Token>(b =>
+            {
+                b.ToTable(EfConstants.TableNames.Token);
+                b.Property(e => e.SubjectId).HasMaxLength(200);
+                b.Property(e => e.ClientId).IsRequired().HasMaxLength(200);
+                b.Property(e => e.JsonCode).IsRequired();
+                b.Property(e => e.Expiry).IsRequired();
+                b.HasKey(e => new { e.Key, e.TokenType });
+            });
+        }
+
+        public static void ConfigureScopeConfigurationContext<TKey>(this ModelBuilder modelBuilder)
+            where TKey : IEquatable<TKey>
+        {
+            modelBuilder.Entity<ScopeClaim<TKey>>(b =>
+            {
+                b.ToTable(EfConstants.TableNames.ScopeClaim);
+                b.Property(e => e.Name).IsRequired().HasMaxLength(200);
+                b.Property(e => e.Description).HasMaxLength(1000);
+            });
+
+            modelBuilder.Entity<ScopeSecret<TKey>>(b =>
+            {
+                b.ToTable(EfConstants.TableNames.ScopeSecrets);
+                b.Property(e => e.Description).HasMaxLength(1000);
+                b.Property(e => e.Type).HasMaxLength(250);
+                b.Property(e => e.Value).IsRequired().HasMaxLength(250);
+            });
+
+            modelBuilder.Entity<Scope<TKey>>(b =>
+            {
+                b.ToTable(EfConstants.TableNames.Scope);
+                b.HasMany(e => e.ScopeClaims).WithOne(e => e.Scope).OnDelete(DeleteBehavior.Cascade);
+                b.HasMany(e => e.ScopeSecrets).WithOne(e => e.Scope).OnDelete(DeleteBehavior.Cascade);
+                b.Property(e => e.Name).IsRequired().HasMaxLength(200);
+                b.Property(e => e.DisplayName).HasMaxLength(200);
+                b.Property(e => e.Description).HasMaxLength(1000);
+                b.Property(e => e.ClaimsRule).HasMaxLength(200);
+            });
+        }
+    }
+}

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Interfaces/IClientConfigurationContext.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Interfaces/IClientConfigurationContext.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Entities;
+
+namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.Interfaces
+{
+    public interface IClientConfigurationContext<TKey>
+        where TKey : IEquatable<TKey>
+    {
+        DbSet<Client<TKey>> Clients { get; set; }
+    }
+}

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Interfaces/IOperationalContext.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Interfaces/IOperationalContext.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Entities;
+
+namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.Interfaces
+{
+    public interface IOperationalContext
+    {
+        DbSet<Consent> Consents { get; set; }
+        DbSet<Token> Tokens { get; set; }
+    }
+}

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Interfaces/IScopeConfigurationContext.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Interfaces/IScopeConfigurationContext.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Entities;
+
+namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.Interfaces
+{
+    public interface IScopeConfigurationContext<TKey>
+        where TKey : IEquatable<TKey>
+    {
+        DbSet<Scope<TKey>> Scopes { get; set; }
+    }
+}

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Services/ClientConfigurationCorsPolicyService.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Services/ClientConfigurationCorsPolicyService.cs
@@ -3,16 +3,16 @@ using Microsoft.EntityFrameworkCore;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using TwentyTwenty.IdentityServer4.EntityFrameworkCore.DbContexts;
+using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Interfaces;
 
 namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.Services
 {
     public class ClientConfigurationCorsPolicyService<TKey> : ICorsPolicyService
         where TKey : IEquatable<TKey>
     {
-        readonly ClientConfigurationContext<TKey> context;
+        readonly IClientConfigurationContext<TKey> context;
 
-        public ClientConfigurationCorsPolicyService(ClientConfigurationContext<TKey> ctx)
+        public ClientConfigurationCorsPolicyService(IClientConfigurationContext<TKey> ctx)
         {
             context = ctx;
         }

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Stores/ClientStore.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Stores/ClientStore.cs
@@ -2,7 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Threading.Tasks;
-using TwentyTwenty.IdentityServer4.EntityFrameworkCore.DbContexts;
+using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Interfaces;
 using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Entities;
 using Models = IdentityServer4.Models;
 
@@ -11,9 +11,9 @@ namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.Stores
     public class ClientStore<TKey> : IClientStore
         where TKey : IEquatable<TKey>
     {
-        private readonly ClientConfigurationContext<TKey> context;
+        private readonly IClientConfigurationContext<TKey> context;
 
-        public ClientStore(ClientConfigurationContext<TKey> context)
+        public ClientStore(IClientConfigurationContext<TKey> context)
         {
             if (context == null) throw new ArgumentNullException("context");
 

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Stores/PersistedGrantService.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Stores/PersistedGrantService.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using IdentityServer4.Models;
 using IdentityServer4.Stores;
-using TwentyTwenty.IdentityServer4.EntityFrameworkCore.DbContexts;
+using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 using IdentityServer4.Stores.Serialization;
@@ -15,13 +15,14 @@ namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.Stores
 {
     public class PersistedGrantService : IPersistedGrantService
     {
-        private readonly OperationalContext _context;
+        private readonly IOperationalContext _context;
         private readonly IScopeStore _scopeStore;
         private readonly IClientStore _clientStore;
 
-        public PersistedGrantService(OperationalContext context, IScopeStore scopeStore, IClientStore clientStore)
+        public PersistedGrantService(IOperationalContext context, IScopeStore scopeStore, IClientStore clientStore)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
+            if (!(context is DbContext)) throw new ArgumentException("Operational context is not a Database Context", nameof(context));
             if (scopeStore == null) throw new ArgumentNullException(nameof(scopeStore));
             if (clientStore == null) throw new ArgumentNullException(nameof(clientStore));
 
@@ -110,7 +111,7 @@ namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.Stores
         {
             var tokens = _context.Tokens.ToArray();
             _context.Tokens.RemoveRange(tokens);
-            await _context.SaveChangesAsync();
+            await ((DbContext)_context).SaveChangesAsync();
         }
 
         public async Task RemoveAuthorizationCodeAsync(string code)
@@ -123,7 +124,7 @@ namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.Stores
             if (token != null)
             {
                 _context.Tokens.Remove(token);
-                await _context.SaveChangesAsync();
+                await ((DbContext)_context).SaveChangesAsync();
             }
         }
 
@@ -137,7 +138,7 @@ namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.Stores
             if (token != null)
             {
                 _context.Tokens.Remove(token);
-                await _context.SaveChangesAsync();
+                await ((DbContext)_context).SaveChangesAsync();
             }
         }
 
@@ -149,7 +150,7 @@ namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.Stores
                 x.TokenType == Entities.TokenType.TokenHandle).ToArray();
 
             _context.Tokens.RemoveRange(found);
-            await _context.SaveChangesAsync();
+            await ((DbContext)_context).SaveChangesAsync();
         }
 
         public async Task RemoveRefreshTokenAsync(string refreshTokenHandle)
@@ -162,7 +163,7 @@ namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.Stores
             if (token != null)
             {
                 _context.Tokens.Remove(token);
-                await _context.SaveChangesAsync();
+                await ((DbContext)_context).SaveChangesAsync();
             }
         }
 
@@ -174,7 +175,7 @@ namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.Stores
                 x.TokenType == Entities.TokenType.RefreshToken).ToArray();
 
             _context.Tokens.RemoveRange(found);
-            await _context.SaveChangesAsync();
+            await ((DbContext)_context).SaveChangesAsync();
         }
 
         public async Task RemoveUserConsent(string subjectId, string clientId)
@@ -186,7 +187,7 @@ namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.Stores
             if (found != null)
             {
                 _context.Consents.Remove(found);
-                await _context.SaveChangesAsync();
+                await ((DbContext)_context).SaveChangesAsync();
             }
         }
 
@@ -203,7 +204,7 @@ namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.Stores
             };
 
             _context.Tokens.Add(token);
-            await _context.SaveChangesAsync();
+            await ((DbContext)_context).SaveChangesAsync();
         }
 
         public async Task StoreReferenceTokenAsync(string handle, Token token)
@@ -219,7 +220,7 @@ namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.Stores
             };
 
             _context.Tokens.Add(storeToken);
-            await _context.SaveChangesAsync();
+            await ((DbContext)_context).SaveChangesAsync();
         }
 
         public async Task StoreRefreshTokenAsync(string handle, RefreshToken refreshToken)
@@ -242,7 +243,7 @@ namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.Stores
             }
 
             token.Expiry = DateTime.UtcNow.AddSeconds(refreshToken.Lifetime);
-            await _context.SaveChangesAsync();
+            await ((DbContext)_context).SaveChangesAsync();
         }
 
         public async Task StoreUserConsent(Consent consent)
@@ -268,7 +269,7 @@ namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.Stores
 
             item.Scopes = consent.Scopes.StringifyScopes();
 
-            await _context.SaveChangesAsync();
+            await ((DbContext)_context).SaveChangesAsync();
         }
 
         private JsonSerializerSettings GetJsonSerializerSettings()

--- a/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Stores/ScopeStore.cs
+++ b/src/TwentyTwenty.IdentityServer4.EntityFrameworkCore/Stores/ScopeStore.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Models = IdentityServer4.Models;
 using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Entities;
-using TwentyTwenty.IdentityServer4.EntityFrameworkCore.DbContexts;
+using TwentyTwenty.IdentityServer4.EntityFrameworkCore.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using IdentityServer4.Stores;
 
@@ -13,9 +13,9 @@ namespace TwentyTwenty.IdentityServer4.EntityFrameworkCore.Stores
     public class ScopeStore<TKey> : IScopeStore
         where TKey : IEquatable<TKey>
     {
-        private readonly ScopeConfigurationContext<TKey> _context;
+        private readonly IScopeConfigurationContext<TKey> _context;
 
-        public ScopeStore(ScopeConfigurationContext<TKey> context)
+        public ScopeStore(IScopeConfigurationContext<TKey> context)
         {
             if (context == null)
             {


### PR DESCRIPTION
Added in how to use the interfaces and context(s) which allows the EntityFramework Migrations on a single DataContext for easy maintenance of the DB

See the readme for more information.

This simplifies the implementation for the implementor and makes it possible to easily use the Migration feature of EntityFramework to build database migrations off a single context
